### PR TITLE
fix(eslint): config will not use eslintrc from this project

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -18,6 +18,33 @@
         "infra",
         "test"
       ]
+    },
+    {
+      "login": "gyandeeps",
+      "name": "Gyandeep Singh",
+      "avatar_url": "https://avatars.githubusercontent.com/u/5554486?v=3",
+      "profile": "http://gyandeeps.com",
+      "contributions": [
+        "review"
+      ]
+    },
+    {
+      "login": "exdeniz",
+      "name": "Igor Pnev",
+      "avatar_url": "https://avatars.githubusercontent.com/u/682584?v=3",
+      "profile": "https://github.com/exdeniz",
+      "contributions": [
+        "bug"
+      ]
+    },
+    {
+      "login": "demoneaux",
+      "name": "Benjamin Tan",
+      "avatar_url": "https://avatars.githubusercontent.com/u/813865?v=3",
+      "profile": "https://demoneaux.github.io/",
+      "contributions": [
+        "question"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formats your JavaScript using [`prettier`][prettier] followed by [`eslint --fix`
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-1-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-4-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -54,6 +54,9 @@ const sourceCode = 'const {foo} = bar'
 const options = {
   text: sourceCode,
   eslintConfig: {
+    parserOptions: {
+      ecmaVersion: 7,
+    },
     rules: {
       semi: ['error', 'never'],
     },
@@ -118,8 +121,8 @@ None that I'm aware of. Feel free to file a PR if you know of any other solution
 Thanks goes to these people ([emoji key][emojis]):
 
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
-| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) |
-| :---: |
+| [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/5554486?v=3" width="100px;"/><br /><sub>Gyandeep Singh</sub>](http://gyandeeps.com)<br />👀 | [<img src="https://avatars.githubusercontent.com/u/682584?v=3" width="100px;"/><br /><sub>Igor Pnev</sub>](https://github.com/exdeniz)<br />[🐛](https://github.com/kentcdodds/prettier-eslint/issues?q=author%3Aexdeniz) | [<img src="https://avatars.githubusercontent.com/u/813865?v=3" width="100px;"/><br /><sub>Benjamin Tan</sub>](https://demoneaux.github.io/)<br />💁 |
+| :---: | :---: | :---: | :---: |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/src/__mocks__/eslint.js
+++ b/src/__mocks__/eslint.js
@@ -35,6 +35,7 @@ function mockGetConfigForFile(filePath) {
   return {
     '/mock/default-config': {
       rules: {
+        semi: [2, 'never'],
         'max-len': [2, 120, 2],
         indent: [2, 2, {SwitchCase: 1}],
         quotes: [2, 'single', {avoidEscape: true, allowTemplateLiterals: true}],

--- a/src/index.js
+++ b/src/index.js
@@ -35,7 +35,8 @@ function format({
 
   try {
     const pretty = prettify(text, prettierOptions)
-    return eslintFix(pretty, eslintConfig)
+    const eslintFixed = eslintFix(pretty, eslintConfig)
+    return eslintFixed
   } finally {
     options.disableLog = originalLogValue
   }
@@ -53,7 +54,13 @@ function prettify(text, formatOptions) {
 
 function eslintFix(text, eslintConfig) {
   const eslintOptions = {
+    // overrideables
+    useEslintrc: false,
+
+    // user-given config
     ...eslintConfig,
+
+    // overrides
     fix: true,
     // there's some trouble with `globals`...
     // I'm pretty sure it's not necessary to have them

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -16,6 +16,24 @@ const tests = [
     output: defaultOutput(),
   },
   {
+    title: 'README example',
+    input: {
+      text: 'const {foo} = bar',
+      eslintConfig: {
+        parserOptions: {
+          ecmaVersion: 7,
+        },
+        rules: {
+          semi: ['error', 'never'],
+        },
+      },
+      prettierOptions: {
+        bracketSpacing: true,
+      },
+    },
+    output: 'const { foo } = bar',
+  },
+  {
     title: 'with a filePath and no config',
     input: {
       text: defaultInputText(),
@@ -110,7 +128,11 @@ test('can disable log on a single call as part of the options', () => {
 
 function getESLintConfigWithDefaultRules(overrides) {
   return {
+    parserOptions: {
+      ecmaVersion: 7,
+    },
     rules: {
+      semi: [2, 'never'],
       'max-len': [2, 120, 2],
       indent: [2, 2, {SwitchCase: 1}],
       quotes: [2, 'single', {avoidEscape: true, allowTemplateLiterals: true}],


### PR DESCRIPTION
There was a problem with the way that eslint fix was applied which
basically resulted in test files in this project inheriting from the
`eslintConfig` from _this project_ (`prettier-eslint`). So I added
`useEslintrc: false` to the config which I believe will fix the issue
(can be overridden)

Also added a test for the README example so this doesn't happen again!

Could I get a review from @exdeniz and @demoneaux (and anyone else interested? ping @gyandeeps?)

Closes #2