### PR TITLE
feat(path): add `eslintPath` and `prettierPath` options

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,6 +98,17 @@ When there's an error, `prettier-eslint` will log it to the console. To disable 
 `disableLog` as an option to the call to `format` or you can set: `format.options.disableLog = true` to disable it
 "globally."
 
+#### eslintPath (?String)
+
+By default, `prettier-eslint` will try to find your project's version of `eslint` (and `prettier`). If it cannot find
+one, then it will use the version that `prettier-eslint` has installed locally. If you'd like to specify a path to the
+`eslint` module you would like to have `prettier-eslint` use, then you can provide the full path to it with the
+`eslintPath` option.
+
+#### prettierPath (?String)
+
+This is basically the same as `eslintPath` except for the `prettier` module.
+
 ### throws
 
 `prettier-eslint` will propagate errors when either `prettier` or `eslint` fails for one reason or another. In addition


### PR DESCRIPTION
So you can specify whether to use your project's version of `eslint` or
`prettier` (if they don't match up for some reason). Or even :shudder:
use a global version :shudder:.

This will be especially useful for the CLI and the atom plugin I think.

Closes #3

Could I get at least one review on this from anyone? :)