### PR TITLE
WIP: add `sillyLogs` option

### DIFF
--- a/README.md
+++ b/README.md
@@ -109,6 +109,12 @@ one, then it will use the version that `prettier-eslint` has installed locally. 
 
 This is basically the same as `eslintPath` except for the `prettier` module.
 
+#### sillyLogs (?Boolean)
+
+When set to `true`, `prettier-eslint` will dump the contents of both the detected `eslintConfig` and `prettierOptions` 
+configuration objects to the console. This defaults to `false` as it is primarily for debugging.
+"globally."
+
 ### throws
 
 `prettier-eslint` will propagate errors when either `prettier` or `eslint` fails for one reason or another. In addition

--- a/src/index.js
+++ b/src/index.js
@@ -1,8 +1,9 @@
+
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
 import path from 'path'
 import {getPrettierOptionsFromESLintRules} from './utils'
 
-const options = {disableLog: false}
+const options = {disableLog: false, sillyLogs: false}
 // CommonJS + ES6 modules... is it worth it? Probably not...
 module.exports = format
 module.exports.options = options
@@ -23,6 +24,7 @@ module.exports.options = options
  * @param {Object} options.prettierOptions - the options to pass for
  *  formatting with `prettier`. If not provided, prettier-eslint will attempt
  *  to create the options based on the eslintConfig
+ * @param {Boolean} options.sillyLogs - enables silly logging (default: false)
  * @return {String} - the formatted string
  */
 function format({
@@ -33,9 +35,17 @@ function format({
   disableLog = options.disableLog,
   eslintConfig = getConfig(filePath, eslintPath),
   prettierOptions = getPrettierOptionsFromESLintRules(eslintConfig),
+  sillyLogs = options.sillyLogs,
 }) {
   const originalLogValue = options.disableLog
   options.disableLog = disableLog
+  if (sillyLogs) {
+    console.log('😜 logs for eslintConfig and prettierOptions:')
+    console.dir({
+      eslintConfig,
+      prettierOptions,
+    }, null, true)
+  }
 
   try {
     // console.log('text', text)

--- a/src/index.js
+++ b/src/index.js
@@ -1,4 +1,3 @@
-
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
 import path from 'path'
 import {getPrettierOptionsFromESLintRules} from './utils'
@@ -39,13 +38,7 @@ function format({
 }) {
   const originalLogValue = options.disableLog
   options.disableLog = disableLog
-  if (sillyLogs) {
-    console.log('😜 logs for eslintConfig and prettierOptions:')
-    console.dir({
-      eslintConfig,
-      prettierOptions,
-    }, null, true)
-  }
+  logSilliness(sillyLogs, eslintConfig, prettierOptions)
 
   try {
     // console.log('text', text)
@@ -138,5 +131,15 @@ function getESLintCLIEngine(eslintPath, eslintOptions) {
 function logError(...args) {
   if (!options.disableLog) {
     console.error('prettier-eslint error:', ...args)
+  }
+}
+
+function logSilliness(sillyLogs, eslintConfig, prettierOptions) {
+  if (sillyLogs) {
+    console.log('😜 logs for eslintConfig and prettierOptions:')
+    console.dir({
+      eslintConfig,
+      prettierOptions,
+    }, null, true)
   }
 }

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -6,6 +6,8 @@ import prettierMock from 'prettier'
 import format from './' // eslint-disable-line import/default
 
 console.error = jest.fn()
+console.log = jest.fn()
+console.dir = jest.fn()
 
 const tests = [
   {
@@ -63,6 +65,8 @@ const tests = [
 
 beforeEach(() => {
   console.error.mockClear()
+  console.log.mockClear()
+  console.dir.mockClear()
   eslintMock.mock.executeOnText.mockClear()
   eslintMock.mock.getConfigForFile.mockClear()
   prettierMock.format.mockClear()
@@ -117,10 +121,11 @@ test('console.error will not be called if disableLog is set', () => {
 test('console receives output of both eslintConfig and prettierOptions when sillyLogs is set', () => {
   format.options.sillyLogs = true
 
+  // expect(format({text: ''})).toHaveBeenCalledWith(console.log, console.dir)
   format({text: ''})
   // TODO: fix this test, since it fails on the matcher toHaveBeenCalledTimes
-  expect(console.log).toHaveBeenCalledTimes(1)
-  expect(console.dir).toHaveBeenCalledTimes(1)
+  expect(console.log).toHaveBeenCalledWith('😜 logs for eslintConfig and prettierOptions:')
+  expect(console.dir).toHaveBeenCalled()
 
   format.options.sillyLogs = false
 })

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -114,6 +114,17 @@ test('console.error will not be called if disableLog is set', () => {
   getConfigForFile.throwError = null
 })
 
+test('console receives output of both eslintConfig and prettierOptions when sillyLogs is set', () => {
+  format.options.sillyLogs = true
+
+  format({text: ''})
+  // TODO: fix this test, since it fails on the matcher toHaveBeenCalledTimes
+  expect(console.log).toHaveBeenCalledTimes(1)
+  expect(console.dir).toHaveBeenCalledTimes(1)
+
+  format.options.sillyLogs = false
+})
+
 test(`when prettier throws, log to console.error but don't fail`, () => {
   const {format: prettierMockFormat} = prettierMock
   const error = 'something bad happened'

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -125,7 +125,12 @@ test('console receives output of both eslintConfig and prettierOptions when sill
   format({text: ''})
   // TODO: fix this test, since it fails on the matcher toHaveBeenCalledTimes
   expect(console.log).toHaveBeenCalledWith('😜 logs for eslintConfig and prettierOptions:')
-  expect(console.dir).toHaveBeenCalled()
+  expect(console.log).toHaveBeenCalledTimes(1)
+  expect(console.dir).toHaveBeenCalledWith(expect.objectContaining({
+    eslintConfig: expect.anything(),
+    prettierOptions: expect.anything(),
+  }), null, true)
+  expect(console.dir).toHaveBeenCalledTimes(1)
 
   format.options.sillyLogs = false
 })


### PR DESCRIPTION
Provides for configuration of whether to dump the `eslintConfig` and `prettierOptions` to the console, defaults to false.