### PR TITLE
fix(prettierOptions): Handle max-len with object configuration

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -76,6 +76,15 @@
         "doc",
         "example"
       ]
+    },
+    {
+      "login": "PAkerstrand",
+      "name": "Patrik Åkerstrand",
+      "avatar_url": "https://avatars.githubusercontent.com/u/463105?v=3",
+      "profile": "https://github.com/PAkerstrand",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formats your JavaScript using [`prettier`][prettier] followed by [`eslint --fix`
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-7-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -144,6 +144,7 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/5554486?v=3" width="100px;"/><br /><sub>Gyandeep Singh</sub>](http://gyandeeps.com)<br />👀 | [<img src="https://avatars.githubusercontent.com/u/682584?v=3" width="100px;"/><br /><sub>Igor Pnev</sub>](https://github.com/exdeniz)<br />[🐛](https://github.com/kentcdodds/prettier-eslint/issues?q=author%3Aexdeniz) | [<img src="https://avatars.githubusercontent.com/u/813865?v=3" width="100px;"/><br /><sub>Benjamin Tan</sub>](https://demoneaux.github.io/)<br />💬 👀 | [<img src="https://avatars.githubusercontent.com/u/622118?v=3" width="100px;"/><br /><sub>Eric McCormick</sub>](https://ericmccormick.io)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) | [<img src="https://avatars.githubusercontent.com/u/2142817?v=3" width="100px;"/><br /><sub>Simon Lydell</sub>](https://github.com/lydell)<br />[📖](https://github.com/kentcdodds/prettier-eslint/commits?author=lydell) | [<img src="https://avatars0.githubusercontent.com/u/981957?v=3" width="100px;"/><br /><sub>Tom McKearney</sub>](https://github.com/tommck)<br />[📖](https://github.com/kentcdodds/prettier-eslint/commits?author=tommck) 💡 |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
+| [<img src="https://avatars.githubusercontent.com/u/463105?v=3" width="100px;"/><br /><sub>Patrik Åkerstrand</sub>](https://github.com/PAkerstrand)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=PAkerstrand) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/package.json
+++ b/package.json
@@ -17,6 +17,7 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
+    "dlv": "^1.1.0",
     "eslint": "^3.13.1",
     "prettier": "^0.17.0",
     "require-relative": "^0.8.7"

--- a/src/utils.js
+++ b/src/utils.js
@@ -1,3 +1,5 @@
+import delve from 'dlv'
+
 /* eslint import/prefer-default-export:0 */
 export {getPrettierOptionsFromESLintRules}
 
@@ -26,7 +28,7 @@ function getPrettierOptionsFromESLintRules(eslintConfig, prettierOptions = {}) {
 }
 
 function getPrintWidth(rules) {
-  return getRuleValue(rules, 'max-len', 80)
+  return getRuleValue(rules, 'max-len', 80, 'code')
 }
 
 function getTabWidth(rules) {
@@ -57,12 +59,14 @@ function getBraketSpacing() {
   return false
 }
 
-function getRuleValue(rules, name, defaultValue) {
+function getRuleValue(rules, name, defaultValue, objPath) {
   const ruleConfig = rules[name]
   if (Array.isArray(ruleConfig)) {
     const [, value] = ruleConfig
     if (typeof value === 'object') {
-      // TODO: handle object configuration
+      if (objPath) {
+        return delve(value, objPath, defaultValue)
+      }
     } else {
       return value
     }

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -31,6 +31,7 @@ const getPrettierOptionsFromESLintRulesTests = [
   // prettier doesn't allow tabs,
   // so we'll just go with the default and let eslint fix it
   {rules: {indent: [2, 'tab']}, options: {tabWidth: 2}},
+  {rules: {'max-len': ['error', {code: 120}]}, options: {printWidth: 120}},
 ]
 
 getPrettierOptionsFromESLintRulesTests.forEach(({rules, options}, index) => {

--- a/yarn.lock
+++ b/yarn.lock
@@ -93,13 +93,14 @@ align-text@^0.1.1, align-text@^0.1.3:
     longest "^1.0.1"
     repeat-string "^1.5.2"
 
-all-contributors-cli@^3.0.7:
-  version "3.1.0"
-  resolved "https://registry.yarnpkg.com/all-contributors-cli/-/all-contributors-cli-3.1.0.tgz#1575e0e7815a933b9fa743b0e214e8c1406beedc"
+all-contributors-cli@^4.0.0:
+  version "4.0.0"
+  resolved "https://registry.npmjs.org/all-contributors-cli/-/all-contributors-cli-4.0.0.tgz#c71e0fd151a0f77dbd2de3d41f3adeb3639de167"
   dependencies:
     async "^2.0.0-rc.1"
-    inquirer "^0.12.0"
+    inquirer "^3.0.1"
     lodash "^4.11.2"
+    pify "^2.3.0"
     request "^2.72.0"
     yargs "^4.7.0"
 
@@ -1185,6 +1186,12 @@ cli-cursor@^1.0.1:
   dependencies:
     restore-cursor "^1.0.1"
 
+cli-cursor@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz#b35dac376479facc3e94747d41d0d0f5238ffcb5"
+  dependencies:
+    restore-cursor "^2.0.0"
+
 cli-table@^0.3.1:
   version "0.3.1"
   resolved "https://registry.yarnpkg.com/cli-table/-/cli-table-0.3.1.tgz#f53b05266a8b1a0b934b3d0821e6e2dc5914ae23"
@@ -1559,6 +1566,10 @@ diffie-hellman@^5.0.0:
     bn.js "^4.1.0"
     miller-rabin "^4.0.0"
     randombytes "^2.0.0"
+
+dlv@^1.1.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/dlv/-/dlv-1.1.0.tgz#fee1a7c43f63be75f3f679e85262da5f102764a7"
 
 doctrine@1.5.0, doctrine@^1.2.2:
   version "1.5.0"
@@ -1946,6 +1957,12 @@ external-editor@^1.1.0:
     spawn-sync "^1.0.15"
     tmp "^0.0.29"
 
+external-editor@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.npmjs.org/external-editor/-/external-editor-2.0.1.tgz#4c597c6c88fa6410e41dbbaa7b1be2336aa31095"
+  dependencies:
+    tmp "^0.0.31"
+
 extglob@^0.3.1:
   version "0.3.2"
   resolved "https://registry.yarnpkg.com/extglob/-/extglob-0.3.2.tgz#2e18ff3d2f49ab2765cec9023f011daa8d8349a1"
@@ -1972,6 +1989,12 @@ figures@^1.3.5:
   dependencies:
     escape-string-regexp "^1.0.5"
     object-assign "^4.1.0"
+
+figures@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz#3ab1a2d2a62c8bfb431a0c94cb797a2fce27c962"
+  dependencies:
+    escape-string-regexp "^1.0.5"
 
 file-entry-cache@^2.0.0:
   version "2.0.0"
@@ -2532,6 +2555,24 @@ inquirer@^0.12.0:
     run-async "^0.1.0"
     rx-lite "^3.1.2"
     string-width "^1.0.1"
+    strip-ansi "^3.0.0"
+    through "^2.3.6"
+
+inquirer@^3.0.1:
+  version "3.0.1"
+  resolved "https://registry.npmjs.org/inquirer/-/inquirer-3.0.1.tgz#6dfbffaf4d697dd76c8fe349f919de01c28afc4d"
+  dependencies:
+    ansi-escapes "^1.1.0"
+    chalk "^1.0.0"
+    cli-cursor "^2.1.0"
+    cli-width "^2.0.0"
+    external-editor "^2.0.1"
+    figures "^2.0.0"
+    lodash "^4.3.0"
+    mute-stream "0.0.7"
+    run-async "^2.2.0"
+    rx "^4.1.0"
+    string-width "^2.0.0"
     strip-ansi "^3.0.0"
     through "^2.3.6"
 
@@ -3459,6 +3500,10 @@ mime@^1.2.11:
   version "1.3.4"
   resolved "https://registry.yarnpkg.com/mime/-/mime-1.3.4.tgz#115f9e3b6b3daf2959983cb38f149a2d40eb5d53"
 
+mimic-fn@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.npmjs.org/mimic-fn/-/mimic-fn-1.1.0.tgz#e667783d92e89dbd342818b5230b9d62a672ad18"
+
 minimalistic-assert@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/minimalistic-assert/-/minimalistic-assert-1.0.0.tgz#702be2dda6b37f4836bcb3f5db56641b64a1d3d3"
@@ -3498,6 +3543,10 @@ mute-stream@0.0.5:
 mute-stream@0.0.6:
   version "0.0.6"
   resolved "https://registry.yarnpkg.com/mute-stream/-/mute-stream-0.0.6.tgz#48962b19e169fd1dfc240b3f1e7317627bbc47db"
+
+mute-stream@0.0.7:
+  version "0.0.7"
+  resolved "https://registry.npmjs.org/mute-stream/-/mute-stream-0.0.7.tgz#3075ce93bc21b8fab43e1bc4da7e8115ed1e7bab"
 
 nan@^2.3.0:
   version "2.5.1"
@@ -3750,6 +3799,12 @@ onetime@^1.0.0:
   version "1.1.0"
   resolved "https://registry.yarnpkg.com/onetime/-/onetime-1.1.0.tgz#a1f7838f8314c516f05ecefcbc4ccfe04b4ed789"
 
+onetime@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/onetime/-/onetime-2.0.0.tgz#52aa8110e52fc5126ffc667bd8ec21c2ed209ce6"
+  dependencies:
+    mimic-fn "^1.0.0"
+
 opt-cli@^1.5.1:
   version "1.5.1"
   resolved "https://registry.yarnpkg.com/opt-cli/-/opt-cli-1.5.1.tgz#04db447b13c96b992eb31685266f4ed0d9736dc2"
@@ -3945,7 +4000,7 @@ pbkdf2@^3.0.3:
   dependencies:
     create-hmac "^1.1.2"
 
-pify@^2.0.0:
+pify@^2.0.0, pify@^2.3.0:
   version "2.3.0"
   resolved "https://registry.yarnpkg.com/pify/-/pify-2.3.0.tgz#ed141a6ac043a849ea588498e7dca8b15330e90c"
 
@@ -4019,6 +4074,21 @@ prettier@^0.13.1:
     ast-types "0.9.4"
     babel-code-frame "6.22.0"
     babylon "6.15.0"
+    esutils "2.0.2"
+    flow-parser "0.38.0"
+    get-stdin "5.0.1"
+    glob "7.1.1"
+    jest-validate "18.2.0"
+    minimist "1.2.0"
+
+prettier@^0.17.0:
+  version "0.17.1"
+  resolved "https://registry.npmjs.org/prettier/-/prettier-0.17.1.tgz#a56cdf72b6ed31cae408b8306f4aeae985570e72"
+  dependencies:
+    ast-types "0.9.4"
+    babel-code-frame "6.22.0"
+    babylon "6.15.0"
+    chalk "1.1.3"
     esutils "2.0.2"
     flow-parser "0.38.0"
     get-stdin "5.0.1"
@@ -4371,6 +4441,13 @@ restore-cursor@^1.0.1:
     exit-hook "^1.0.0"
     onetime "^1.0.0"
 
+restore-cursor@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz#9f7ee287f82fd326d4fd162923d62129eee0dfaf"
+  dependencies:
+    onetime "^2.0.0"
+    signal-exit "^3.0.2"
+
 retry@^0.10.0:
   version "0.10.1"
   resolved "https://registry.yarnpkg.com/retry/-/retry-0.10.1.tgz#e76388d217992c252750241d3d3956fed98d8ff4"
@@ -4533,7 +4610,7 @@ shellwords@^0.1.0:
   version "0.1.0"
   resolved "https://registry.yarnpkg.com/shellwords/-/shellwords-0.1.0.tgz#66afd47b6a12932d9071cbfd98a52e785cd0ba14"
 
-signal-exit@^3.0.0:
+signal-exit@^3.0.0, signal-exit@^3.0.2:
   version "3.0.2"
   resolved "https://registry.yarnpkg.com/signal-exit/-/signal-exit-3.0.2.tgz#b5fdc08f1287ea1178628e415e25132b73646c6d"
 
@@ -4835,6 +4912,12 @@ timers-browserify@^2.0.2:
 tmp@^0.0.29:
   version "0.0.29"
   resolved "https://registry.yarnpkg.com/tmp/-/tmp-0.0.29.tgz#f25125ff0dd9da3ccb0c2dd371ee1288bb9128c0"
+  dependencies:
+    os-tmpdir "~1.0.1"
+
+tmp@^0.0.31:
+  version "0.0.31"
+  resolved "https://registry.npmjs.org/tmp/-/tmp-0.0.31.tgz#8f38ab9438e17315e5dbd8b3657e8bfb277ae4a7"
   dependencies:
     os-tmpdir "~1.0.1"
 


### PR DESCRIPTION
Currently, if you try to specify `max-len` using the `options`-object rather than a number, `prettier` is called with `printWidth: 80`.

```
# --- .eslintrc

"rules": {
  "max-len": ["error", { 
    "code": 120,
    ...
  }],
  ...
},
```

With this PR, we handle this case by looking at the `code`-property and use that as the option to `prettier`