### PR TITLE
feat(logging): add really nice logging capabilities

### DIFF
--- a/README.md
+++ b/README.md
@@ -94,11 +94,10 @@ The options to pass for formatting with `prettier`. If not provided, `prettier-e
 options based on the `eslintConfig` (whether that's provided or derived via `filePath`). You can also provide _some_ of
 the options and have the remaining options derived via your eslint config. This is useful for options like `parser`.
 
-#### disableLog (?Boolean)
+#### logLevel (?Enum: ['trace', 'debug', 'info', 'warn', 'error', 'silent'])
 
-When there's an error, `prettier-eslint` will log it to the console. To disable this behavior you can either pass
-`disableLog` as an option to the call to `format` or you can set: `format.options.disableLog = true` to disable it
-"globally."
+`prettier-eslint` does quite a bit of logging if you want it to. Pass this to set the amount of logs you want to see.
+Default is `process.env.LOG_LEVEL || 'warn'`.
 
 #### eslintPath (?String)
 
@@ -110,12 +109,6 @@ with the `eslintPath` option.
 #### prettierPath (?String)
 
 This is basically the same as `eslintPath` except for the `prettier` module.
-
-#### sillyLogs (?Boolean)
-
-When set to `true`, `prettier-eslint` will dump the contents of both the detected `eslintConfig` and `prettierOptions`
-configuration objects to the console. This defaults to `false` as it is primarily for debugging.
-"globally."
 
 ### throws
 

--- a/package.json
+++ b/package.json
@@ -17,9 +17,12 @@
   "author": "Kent C. Dodds <kent@doddsfamily.us> (http://kentcdodds.com/)",
   "license": "MIT",
   "dependencies": {
+    "common-tags": "^1.4.0",
     "dlv": "^1.1.0",
     "eslint": "^3.13.1",
+    "loglevel": "^1.4.1",
     "prettier": "^0.18.0",
+    "pretty-format": "^18.1.0",
     "require-relative": "^0.8.7"
   },
   "devDependencies": {
@@ -30,11 +33,13 @@
     "babel-preset-latest": "^6.16.0",
     "babel-preset-stage-2": "^6.18.0",
     "babel-register": "^6.18.0",
+    "chalk": "^1.1.3",
     "codecov": "^1.0.1",
     "commitizen": "^2.8.6",
     "cz-conventional-changelog": "^1.2.0",
     "eslint-config-kentcdodds": "^11.1.0",
     "husky": "^0.13.1",
+    "indent-string": "^3.1.0",
     "jest-cli": "^18.1.0",
     "opt-cli": "^1.5.1",
     "p-s": "^3.0.3",

--- a/src/__mocks__/fs.js
+++ b/src/__mocks__/fs.js
@@ -1,0 +1,4 @@
+const fs = require.requireActual('fs')
+module.exports = Object.assign({}, fs, {
+  readFileSync: jest.fn(() => 'var fake = true'),
+})

--- a/src/__mocks__/loglevel.js
+++ b/src/__mocks__/loglevel.js
@@ -1,0 +1,30 @@
+const logger = {
+  setLevel: jest.fn(),
+  trace: jest.fn(getTestImplementation('trace')),
+  debug: jest.fn(getTestImplementation('debug')),
+  info: jest.fn(getTestImplementation('info')),
+  warn: jest.fn(getTestImplementation('warn')),
+  error: jest.fn(getTestImplementation('error')),
+}
+const mock = {clearAll, logger, logThings: []}
+module.exports = {getLogger: jest.fn(getLogger), mock}
+
+function getLogger() {
+  return logger
+}
+
+function clearAll() {
+  Object.keys(logger).forEach(name => {
+    logger[name].mock && logger[name].mockClear()
+  })
+}
+
+function getTestImplementation(level) {
+  return testLogImplementation
+
+  function testLogImplementation(...args) {
+    if (mock.logThings === 'all' || mock.logThings.indexOf(level) !== -1) {
+      console.log(level, ...args) // eslint-disable-line no-console
+    }
+  }
+}

--- a/src/index.js
+++ b/src/index.js
@@ -1,112 +1,166 @@
 /* eslint no-console:0, global-require:0, import/no-dynamic-require:0 */
+import fs from 'fs'
 import path from 'path'
 import requireRelative from 'require-relative'
-import {getPrettierOptionsFromESLintRules} from './utils'
+import prettyFormat from 'pretty-format'
+import {oneLine, stripIndent} from 'common-tags'
+import indentString from 'indent-string'
+import {getOptionsForFormatting} from './utils'
+import getLogger from './log'
 
-const options = {disableLog: false, sillyLogs: false}
+const defaultLogLevel = process.env.LOG_LEVEL || 'WARN'
+const logger = getLogger(defaultLogLevel)
+
 // CommonJS + ES6 modules... is it worth it? Probably not...
 module.exports = format
-module.exports.options = options
 
 /**
  * Formats the text with prettier and then eslint based on the given options
- * @param {String} options.text - the text (JavaScript code) to format
  * @param {String} options.filePath - the path of the file being formatted
  *  can be used in leu of `eslintConfig` (eslint will be used to find the
- *  relevant config for the file)
+ *  relevant config for the file). Will also be used to load the `text` if
+ *  `text` is not provided.
+ * @param {String} options.text - the text (JavaScript code) to format
  * @param {String} options.eslintPath - the path to the eslint module to use.
  *   Will default to require.resolve('eslint')
  * @param {String} options.prettierPath - the path to the prettier module.
  *   Will default to require.resovlve('prettierPath')
- * @param {Boolean} options.disableLog - disables any logging
  * @param {String} options.eslintConfig - the config to use for formatting
  *  with ESLint.
  * @param {Object} options.prettierOptions - the options to pass for
  *  formatting with `prettier`. If not provided, prettier-eslint will attempt
  *  to create the options based on the eslintConfig
- * @param {Boolean} options.sillyLogs - enables silly logging (default: false)
+ * @param {Boolean} options.logLevel - the level for the logs
+ *  (error, warn, info, debug, trace)
  * @return {String} - the formatted string
  */
-function format(
-  {
-    text,
-    filePath,
-    eslintPath = getModulePath(filePath, 'eslint'),
-    prettierPath = getModulePath(filePath, 'prettier'),
-    disableLog = options.disableLog,
-    eslintConfig = getConfig(filePath, eslintPath),
-    prettierOptions,
-    sillyLogs = options.sillyLogs,
-  },
-) {
-  prettierOptions = getPrettierOptionsFromESLintRules(
-    eslintConfig,
-    prettierOptions,
-  )
-  const originalLogValue = options.disableLog
-  options.disableLog = disableLog
-  logSilliness(sillyLogs, eslintConfig, prettierOptions)
-
+function format(options) {
   try {
-    // console.log('text', text)
-    const pretty = prettify(text, prettierOptions, prettierPath)
-    // console.log('pretty', pretty)
-    const eslintFixed = eslintFix(pretty, eslintConfig, eslintPath)
-    // console.log('eslintFixed', eslintFixed)
+    const {logLevel = defaultLogLevel} = options
+    logger.setLevel(logLevel)
+    logger.trace('called format with options:', prettyFormat(options))
+
+    const {
+      filePath,
+      text = getTextFromFilePath(filePath),
+      eslintPath = getModulePath(filePath, 'eslint'),
+      prettierPath = getModulePath(filePath, 'prettier'),
+      eslintConfig = getConfig(filePath, eslintPath),
+      prettierOptions,
+    } = options
+    const formattingOptions = getOptionsForFormatting(
+      eslintConfig,
+      prettierOptions,
+    )
+    logger.debug(
+      'inferred options:',
+      prettyFormat({
+        filePath,
+        text,
+        eslintPath,
+        prettierPath,
+        eslintConfig: formattingOptions.eslint,
+        prettierOptions: formattingOptions.prettier,
+        logLevel,
+      }),
+    )
+
+    logger.debug('calling prettier on text')
+    logger.trace(
+      stripIndent`
+        prettier input:
+
+        ${indentString(text, 2)}
+      `,
+    )
+    const pretty = prettify(text, formattingOptions.prettier, prettierPath)
+    logger.trace(
+      stripIndent`
+        prettier output (eslint input):
+
+        ${indentString(pretty, 2)}
+      `,
+    )
+    const eslintFixed = eslintFix(pretty, formattingOptions.eslint, eslintPath)
+    logger.trace(
+      stripIndent`
+        eslint --fix output (final formatted result):
+
+        ${indentString(pretty, 2)}
+      `,
+    )
     return eslintFixed
   } finally {
-    options.disableLog = originalLogValue
+    logger.setLevel(defaultLogLevel)
   }
 }
 
 function prettify(text, formatOptions, prettierPath) {
   let prettier
   try {
+    logger.trace(`requiring prettier module at "${prettierPath}"`)
     prettier = require(prettierPath)
   } catch (error) {
-    logError(
-      'There was trouble getting prettier. ' +
-        `Is "prettierPath: ${prettierPath}" ` +
-        'a correct path to the prettier module?',
+    logger.error(
+      oneLine`
+        There was trouble getting prettier.
+        Is "prettierPath: ${prettierPath}"
+        a correct path to the prettier module?
+      `,
     )
     throw error
   }
   try {
-    return prettier.format(text, formatOptions)
+    logger.trace(`calling prettier.format with the text and prettierOptions`)
+    const output = prettier.format(text, formatOptions)
+    logger.trace('prettier: output === input', output === text)
+    return output
   } catch (error) {
-    // is this noisy? Try setting options.disableLog to false
-    logError('prettier formatting failed', error.stack)
+    logger.error('prettier formatting failed due to a prettier error')
     throw error
   }
 }
 
 function eslintFix(text, eslintConfig, eslintPath) {
-  const eslintOptions = {
-    // overrideables
-    useEslintrc: false,
-    // user-given config
-    ...eslintConfig,
-    // overrides
-    fix: true,
-    // there's some trouble with `globals`...
-    // I'm pretty sure it's not necessary to have them
-    // for a --fix though so :shrug:
-    globals: [],
-  }
-  const eslint = getESLintCLIEngine(eslintPath, eslintOptions)
+  const eslint = getESLintCLIEngine(eslintPath, eslintConfig)
   try {
+    logger.trace(`calling eslint.executeOnText with the text`)
     const report = eslint.executeOnText(text)
+    logger.trace(
+      `executeOnText returned the following report:`,
+      prettyFormat(report),
+    )
     // default the output to text because if there's nothing
     // to fix, eslint doesn't provide `output`
     const [{output = text}] = report.results
+    logger.trace('eslint --fix: output === input', output === text)
     // NOTE: We're ignoring linting errors/warnings here and
     // defaulting to the given text if there are any
     // because all we're trying to do is fix what we can.
     // We don't care about what we can't
     return output
   } catch (error) {
-    // is this noisy? Try setting options.disableLog to false
-    logError('eslint fix failed', error.stack)
+    logger.error('eslint fix failed due to an eslint error')
+    throw error
+  }
+}
+
+function getTextFromFilePath(filePath) {
+  try {
+    logger.trace(
+      oneLine`
+        attempting fs.readFileSync to get
+        the text for file at "${filePath}"
+      `,
+    )
+    return fs.readFileSync(filePath, 'utf8')
+  } catch (error) {
+    logger.error(
+      oneLine`
+        failed to get the text to format
+        from the given filePath: "${filePath}"
+      `,
+    )
     throw error
   }
 }
@@ -116,13 +170,24 @@ function getConfig(filePath, eslintPath) {
   if (filePath) {
     eslintOptions.cwd = path.dirname(filePath)
   }
+  logger.trace(
+    oneLine`
+      creating ESLint CLI Engine to get the config for
+      "${filePath || process.cwd()}"
+    `,
+  )
   const configFinder = getESLintCLIEngine(eslintPath, eslintOptions)
   try {
+    logger.debug(`getting eslint config for file at "${filePath}"`)
     const config = configFinder.getConfigForFile(filePath)
+    logger.trace(
+      `eslint config for "${filePath}" received`,
+      prettyFormat(config),
+    )
     return config
   } catch (error) {
     // is this noisy? Try setting options.disableLog to false
-    logError('Unable to find config', error.stack)
+    logger.error('Unable to find config')
     throw error
   }
 }
@@ -131,9 +196,12 @@ function getModulePath(filePath = __filename, moduleName) {
   try {
     return requireRelative.resolve(moduleName, filePath)
   } catch (error) {
-    logError(
-      `There was a problem finding the ${moduleName} ` +
-        `module. Using prettier-eslint's version`,
+    logger.debug(
+      oneLine`
+        There was a problem finding the ${moduleName}
+        module. Using prettier-eslint's version.
+      `,
+      error.message,
       error.stack,
     )
     return require.resolve(moduleName)
@@ -142,26 +210,16 @@ function getModulePath(filePath = __filename, moduleName) {
 
 function getESLintCLIEngine(eslintPath, eslintOptions) {
   try {
+    logger.trace(`requiring eslint module at "${eslintPath}"`)
     const {CLIEngine} = require(eslintPath)
     return new CLIEngine(eslintOptions)
   } catch (error) {
-    logError(
-      'There was trouble creating the ESLint CLIEngine. ' +
-        `Is "eslintPath: ${eslintPath}" a correct path to the ESLint module?`,
+    logger.error(
+      oneLine`
+        There was trouble creating the ESLint CLIEngine.
+        Is "eslintPath: ${eslintPath}" a correct path to the ESLint module?
+      `,
     )
     throw error
-  }
-}
-
-function logError(...args) {
-  if (!options.disableLog) {
-    console.error('prettier-eslint error:', ...args)
-  }
-}
-
-function logSilliness(sillyLogs, eslintConfig, prettierOptions) {
-  if (sillyLogs) {
-    console.log('silly logs for eslintConfig and prettierOptions:')
-    console.dir({eslintConfig, prettierOptions}, {depth: null, colors: true})
   }
 }

--- a/src/log.js
+++ b/src/log.js
@@ -1,0 +1,44 @@
+import {getLogger} from 'loglevel'
+import chalk from 'chalk'
+
+let logger
+
+export default setupLogger
+
+function setupLogger(level = 'WARN') {
+  if (logger) {
+    return logger
+  }
+  const prefix = chalk.dim('prettier-eslint')
+  const levelPrefix = {
+    TRACE: chalk.dim('[TRACE]'),
+    DEBUG: chalk.dim.cyan('[DEBUG]'),
+    INFO: chalk.dim.blue('[INFO]'),
+    WARN: chalk.dim.yellow('[WARN]'),
+    ERROR: chalk.dim.red('[ERROR]'),
+  }
+
+  logger = getLogger(`prettier-eslint-logger`)
+
+  // this is the plugin "api"
+  const originalFactory = logger.methodFactory
+  logger.methodFactory = methodFactory
+
+  const originalSetLevel = logger.setLevel
+  logger.setLevel = setLevel
+  logger.setLevel(level)
+  return logger
+
+  // this is the plugin "api"
+  function methodFactory(...factoryArgs) {
+    const {0: logLevel} = factoryArgs
+    const rawMethod = originalFactory(...factoryArgs)
+    return (...args) =>
+      rawMethod(`${prefix} ${levelPrefix[logLevel.toUpperCase()]}:`, ...args)
+  }
+
+  function setLevel(levelToSetTo) {
+    const persist = false // uses browser localStorage
+    return originalSetLevel.call(logger, levelToSetTo, persist)
+  }
+}

--- a/src/log.test.js
+++ b/src/log.test.js
@@ -1,0 +1,31 @@
+/* eslint no-console:0 */
+import getLogger from './log'
+
+jest.unmock('loglevel')
+
+const logMap = {
+  trace: 'trace',
+  debug: 'log',
+  info: 'info',
+  warn: 'warn',
+  error: 'error',
+}
+
+Object.keys(logMap).forEach(logLevel => {
+  console[logMap[logLevel]] = jest.fn()
+})
+
+const logger = getLogger('trace')
+
+Object.keys(logMap).forEach(logLevel => {
+  const logMethod = logMap[logLevel]
+  const message = `Help me Obi Wan Kenobi. You're my only hope.`
+  test(`${logLevel} logs to console.${logMethod}`, () => {
+    logger[logLevel](message)
+    expect(console[logMethod]).toHaveBeenCalledTimes(1)
+    const prefix = expect.stringMatching(
+      new RegExp(`prettier-eslint.*${logLevel.toUpperCase()}`),
+    )
+    expect(console[logMethod]).toHaveBeenCalledWith(prefix, message)
+  })
+})

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -1,4 +1,4 @@
-import {getPrettierOptionsFromESLintRules} from './utils'
+import {getOptionsForFormatting} from './utils'
 
 const getPrettierOptionsFromESLintRulesTests = [
   {
@@ -36,15 +36,31 @@ const getPrettierOptionsFromESLintRulesTests = [
 
 getPrettierOptionsFromESLintRulesTests.forEach(({rules, options}, index) => {
   test(`getPrettierOptionsFromESLintRulesTests ${index}`, () => {
-    const actualOptions = getPrettierOptionsFromESLintRules({rules})
-    expect(actualOptions).toMatchObject(options)
+    const {prettier} = getOptionsForFormatting({rules})
+    expect(prettier).toMatchObject(options)
   })
 })
 
 test('if prettierOptions are provided, those are preferred', () => {
-  const actualOptions = getPrettierOptionsFromESLintRules(
-    {rules: {quotes: [2, 'single']}},
-    {singleQuote: false},
-  )
-  expect(actualOptions).toMatchObject({singleQuote: false})
+  const {prettier} = getOptionsForFormatting({rules: {quotes: [2, 'single']}}, {
+    singleQuote: false,
+  })
+  expect(prettier).toMatchObject({singleQuote: false})
+})
+
+test('eslint config has only necessary properties', () => {
+  const {eslint} = getOptionsForFormatting({
+    globals: {window: false},
+    rules: {'no-var': 'error', quotes: [2, 'single']},
+  })
+  expect(eslint).toMatchObject({
+    fix: true,
+    useEslintrc: false,
+    rules: {quotes: [2, 'single']},
+  })
+})
+
+test('useEslintrc is set to the given config value', () => {
+  const {eslint} = getOptionsForFormatting({useEslintrc: true, rules: {}})
+  expect(eslint).toMatchObject({fix: true, useEslintrc: true})
 })

--- a/yarn.lock
+++ b/yarn.lock
@@ -1294,6 +1294,12 @@ commitizen@^2.8.6:
     shelljs "0.7.5"
     strip-json-comments "2.0.1"
 
+common-tags@^1.4.0:
+  version "1.4.0"
+  resolved "https://registry.yarnpkg.com/common-tags/-/common-tags-1.4.0.tgz#1187be4f3d4cf0c0427d43f74eef1f73501614c0"
+  dependencies:
+    babel-runtime "^6.18.0"
+
 concat-map@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/concat-map/-/concat-map-0.0.1.tgz#d8a96bd77fd68df7793a73036a3ba0d5405d477b"
@@ -2498,6 +2504,10 @@ indent-string@^2.1.0:
   dependencies:
     repeating "^2.0.0"
 
+indent-string@^3.1.0:
+  version "3.1.0"
+  resolved "https://registry.yarnpkg.com/indent-string/-/indent-string-3.1.0.tgz#08ff4334603388399b329e6b9538dc7a3cf5de7d"
+
 indexof@0.0.1:
   version "0.0.1"
   resolved "https://registry.yarnpkg.com/indexof/-/indexof-0.0.1.tgz#82dc336d232b9062179d05ab3293a66059fd435d"
@@ -3362,6 +3372,10 @@ lodash@~1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-1.3.1.tgz#a4663b53686b895ff074e2ba504dfb76a8e2b770"
 
+loglevel@^1.4.1:
+  version "1.4.1"
+  resolved "https://registry.yarnpkg.com/loglevel/-/loglevel-1.4.1.tgz#95b383f91a3c2756fd4ab093667e4309161f2bcd"
+
 longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
@@ -4081,9 +4095,9 @@ prettier@^0.13.1:
     jest-validate "18.2.0"
     minimist "1.2.0"
 
-prettier@^0.17.0:
-  version "0.17.1"
-  resolved "https://registry.npmjs.org/prettier/-/prettier-0.17.1.tgz#a56cdf72b6ed31cae408b8306f4aeae985570e72"
+prettier@^0.18.0:
+  version "0.18.0"
+  resolved "https://registry.yarnpkg.com/prettier/-/prettier-0.18.0.tgz#9ef5918d53a56946cbc90c213be0db0b0aaea73c"
   dependencies:
     ast-types "0.9.4"
     babel-code-frame "6.22.0"


### PR DESCRIPTION
BREAKING CHANGE: `disableLog` and `sillyLogs` no longer available. You should use `logLevel` instead

**before**:

```javascript
format({disableLog: true})
```

**after**:

```javascript
format({logLevel: 'silent'})
```

**before**:

```javascript
format({sillyLogs: true})
```

**after**:

```javascript
format({logLevel: 'trace'})
```