### PR TITLE
fix(prettierOptions): add eslint config inference for 'bracketSpacing'

### DIFF
--- a/.all-contributorsrc
+++ b/.all-contributorsrc
@@ -85,6 +85,15 @@
       "contributions": [
         "code"
       ]
+    },
+    {
+      "login": "loklaan",
+      "name": "Lochlan Bunn",
+      "avatar_url": "https://avatars.githubusercontent.com/u/1560301?v=3",
+      "profile": "https://twitter.com/loklaan",
+      "contributions": [
+        "code"
+      ]
     }
   ]
 }

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Formats your JavaScript using [`prettier`][prettier] followed by [`eslint --fix`
 [![downloads][downloads-badge]][npm-stat]
 [![MIT License][license-badge]][LICENSE]
 
-[![All Contributors](https://img.shields.io/badge/all_contributors-8-orange.svg?style=flat-square)](#contributors)
+[![All Contributors](https://img.shields.io/badge/all_contributors-9-orange.svg?style=flat-square)](#contributors)
 [![PRs Welcome][prs-badge]][prs]
 [![Donate][donate-badge]][donate]
 [![Code of Conduct][coc-badge]][coc]
@@ -137,7 +137,7 @@ Thanks goes to these people ([emoji key][emojis]):
 <!-- ALL-CONTRIBUTORS-LIST:START - Do not remove or modify this section -->
 | [<img src="https://avatars.githubusercontent.com/u/1500684?v=3" width="100px;"/><br /><sub>Kent C. Dodds</sub>](https://kentcdodds.com)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) 🚇 [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=kentcdodds) | [<img src="https://avatars.githubusercontent.com/u/5554486?v=3" width="100px;"/><br /><sub>Gyandeep Singh</sub>](http://gyandeeps.com)<br />👀 | [<img src="https://avatars.githubusercontent.com/u/682584?v=3" width="100px;"/><br /><sub>Igor Pnev</sub>](https://github.com/exdeniz)<br />[🐛](https://github.com/kentcdodds/prettier-eslint/issues?q=author%3Aexdeniz) | [<img src="https://avatars.githubusercontent.com/u/813865?v=3" width="100px;"/><br /><sub>Benjamin Tan</sub>](https://demoneaux.github.io/)<br />💬 👀 | [<img src="https://avatars.githubusercontent.com/u/622118?v=3" width="100px;"/><br /><sub>Eric McCormick</sub>](https://ericmccormick.io)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) [📖](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) [⚠️](https://github.com/kentcdodds/prettier-eslint/commits?author=edm00se) | [<img src="https://avatars.githubusercontent.com/u/2142817?v=3" width="100px;"/><br /><sub>Simon Lydell</sub>](https://github.com/lydell)<br />[📖](https://github.com/kentcdodds/prettier-eslint/commits?author=lydell) | [<img src="https://avatars0.githubusercontent.com/u/981957?v=3" width="100px;"/><br /><sub>Tom McKearney</sub>](https://github.com/tommck)<br />[📖](https://github.com/kentcdodds/prettier-eslint/commits?author=tommck) 💡 |
 | :---: | :---: | :---: | :---: | :---: | :---: | :---: |
-| [<img src="https://avatars.githubusercontent.com/u/463105?v=3" width="100px;"/><br /><sub>Patrik Åkerstrand</sub>](https://github.com/PAkerstrand)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=PAkerstrand) |
+| [<img src="https://avatars.githubusercontent.com/u/463105?v=3" width="100px;"/><br /><sub>Patrik Åkerstrand</sub>](https://github.com/PAkerstrand)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=PAkerstrand) | [<img src="https://avatars.githubusercontent.com/u/1560301?v=3" width="100px;"/><br /><sub>Lochlan Bunn</sub>](https://twitter.com/loklaan)<br />[💻](https://github.com/kentcdodds/prettier-eslint/commits?author=loklaan) |
 <!-- ALL-CONTRIBUTORS-LIST:END -->
 
 This project follows the [all-contributors][all-contributors] specification. Contributions of any kind welcome!

--- a/src/index.test.js
+++ b/src/index.test.js
@@ -46,6 +46,30 @@ const tests = [
     input: {text: defaultInputText()},
     output: defaultOutput(),
   },
+  {
+    title: 'inferring bracketSpacing',
+    input: {
+      text: 'var foo = {bar: baz};',
+      eslintConfig: {rules: {'object-curly-spacing': ['error', 'always']}},
+    },
+    output: 'var foo = { bar: baz };',
+  },
+  {
+    title: 'inferring bracketSpacing with eslint object-curly-spacing options',
+    input: {
+      text: 'var foo = {bar: {baz: qux}};\nvar fop = {bar: [1, 2, 3]};',
+      eslintConfig: {
+        rules: {
+          'object-curly-spacing': [
+            'error',
+            'always',
+            {objectsInObjects: false, arraysInObjects: false},
+          ],
+        },
+      },
+    },
+    output: 'var foo = { bar: { baz: qux }};\nvar fop = { bar: [1, 2, 3]};',
+  },
   // if you have a bug report or something,
   // go ahead and add a test case here
   {

--- a/src/utils.js
+++ b/src/utils.js
@@ -126,9 +126,9 @@ function getParser() {
   return 'babylon'
 }
 
-function getBraketSpacing() {
-  // TODO: handle braketSpacing
-  return false
+function getBraketSpacing(rules) {
+  const value = getRuleValue(rules, 'object-curly-spacing', 'never')
+  return value !== 'never'
 }
 
 function getRuleValue(rules, name, defaultValue, objPath) {

--- a/src/utils.test.js
+++ b/src/utils.test.js
@@ -26,6 +26,14 @@ const getPrettierOptionsFromESLintRulesTests = [
       bracketSpacing: false,
     },
   },
+  {
+    rules: {'object-curly-spacing': [2, 'always']},
+    options: {bracketSpacing: true},
+  },
+  {
+    rules: {'object-curly-spacing': [2, 'never']},
+    options: {bracketSpacing: false},
+  },
   {rules: {'max-len': 2}, options: {printWidth: 80}},
   {rules: {'comma-dangle': [2, 'never']}, options: {trailingComma: 'none'}},
   {rules: {'comma-dangle': [2, 'always']}, options: {trailingComma: 'all'}},


### PR DESCRIPTION
The `bracketSpacing` option for prettier can be inferred from the eslint [`object-curly-braces`][curly] config. Correct me if I am wrong on the assumption 😉.

The [options][curly-options] for the `object-curly-spacing` will work without any extra configuration. Tests have been added to confirm/track this assertion.

P.S. Stumbled onto fixing this by reading kentcdodds/prettier-eslint-cli#26! It doesn't resolve the issue, but it should help it along I suppose.

[curly]: http://eslint.org/docs/rules/object-curly-spacing
[curly-options]: http://eslint.org/docs/rules/object-curly-spacing#options

