### PR TITLE
chore: prepare stable release

### DIFF
--- a/.changeset/pre.json
+++ b/.changeset/pre.json
@@ -1,5 +1,5 @@
 {
-  "mode": "pre",
+  "mode": "exit",
   "tag": "alpha",
   "initialVersions": {
     "prettier-eslint": "16.4.2"

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -37,12 +37,10 @@ jobs:
 
       - name: Create Release Pull Request or Publish to npm
         id: changesets
-        uses: changesets/action@v1
+        uses: changesets/action@a45c4d594aa4e2c509dc14a9f2b3b67ba3780d0d # v1.9.0
         with:
           commit: 'chore: release prettier-eslint'
           title: 'chore: release prettier-eslint'
           publish: yarn start release
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-          NPM_CONFIG_PROVENANCE: true
-          NPM_TOKEN: ${{ secrets.NPM_TOKEN }}


### PR DESCRIPTION
## Summary
- Exit Changesets prerelease mode for the stable release.
- Pin the Changesets release action to v1.9.0.
- Remove npm publish token/provenance env from the release workflow.

## Test plan
- [x] `nps lint`
- [x] `nps build`
- [x] `nps test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated internal release configuration and CI/CD workflow settings.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->