### PR TITLE
Align loglevel type exports

### DIFF
--- a/.changeset/fresh-donkeys-explain.md
+++ b/.changeset/fresh-donkeys-explain.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+Align exported log level types with `loglevel`.

--- a/__mocks__/loglevel-colored-level-prefix.ts
+++ b/__mocks__/loglevel-colored-level-prefix.ts
@@ -1,16 +1,14 @@
 import type { Logger, LogLevelNames as LogLevel } from 'loglevel';
 import type { GetLogger } from 'loglevel-colored-level-prefix';
 
-const logger: Logger = {
+const logger = {
   setLevel: jest.fn(),
   debug: jest.fn(getTestImplementation('debug')),
   error: jest.fn(getTestImplementation('error')),
   info: jest.fn(getTestImplementation('info')),
-  // @ts-expect-error - loglevel's typings are wrong for this method
-  silent: jest.fn(getTestImplementation('silent')),
   trace: jest.fn(getTestImplementation('trace')),
   warn: jest.fn(getTestImplementation('warn')),
-};
+} as unknown as Logger;
 
 const mock: (typeof getLogger)['mock'] = { clearAll, logger, logThings: [] };
 

--- a/__mocks__/loglevel-colored-level-prefix.ts
+++ b/__mocks__/loglevel-colored-level-prefix.ts
@@ -1,14 +1,12 @@
-import type {
-  GetLogger,
-  Logger,
-  LogLevel,
-} from 'loglevel-colored-level-prefix';
+import type { Logger, LogLevelNames as LogLevel } from 'loglevel';
+import type { GetLogger } from 'loglevel-colored-level-prefix';
 
 const logger: Logger = {
   setLevel: jest.fn(),
   debug: jest.fn(getTestImplementation('debug')),
   error: jest.fn(getTestImplementation('error')),
   info: jest.fn(getTestImplementation('info')),
+  // @ts-expect-error - loglevel's typings are wrong for this method
   silent: jest.fn(getTestImplementation('silent')),
   trace: jest.fn(getTestImplementation('trace')),
   warn: jest.fn(getTestImplementation('warn')),
@@ -16,7 +14,7 @@ const logger: Logger = {
 
 const mock: (typeof getLogger)['mock'] = { clearAll, logger, logThings: [] };
 
-const getLogger = (() => logger) as unknown as GetLogger;
+const getLogger = (() => logger) as GetLogger;
 
 Object.assign(getLogger, { mock });
 
@@ -24,7 +22,7 @@ export = getLogger;
 
 function clearAll() {
   for (const name of Object.keys(logger) as LogLevel[]) {
-    logger[name].mockClear();
+    (logger[name] as jest.Mock).mockClear();
   }
 }
 

--- a/shim.d.ts
+++ b/shim.d.ts
@@ -11,29 +11,20 @@ declare module 'eslint-plugin-node-dependencies' {
 }
 
 declare module 'loglevel-colored-level-prefix' {
-  namespace getLogger {
-    type LogLevel = 'debug' | 'error' | 'info' | 'silent' | 'trace' | 'warn';
+  import { LogLevelDesc, Logger } from 'loglevel';
 
-    interface Logger extends Record<
-      LogLevel,
-      jest.Mock<void, [message: string, ...args: unknown[]]>
-    > {
-      setLevel: (level: LogLevel) => void;
-    }
+  export interface GetLogger {
+    (options?: { level?: LogLevelDesc; prefix?: string }): Logger;
 
-    interface GetLogger {
-      (options: { prefix: string }): Logger;
-
-      // testing mock
-      mock: {
-        logThings: LogLevel[] | 'all';
-        logger: Logger;
-        clearAll(): void;
-      };
-    }
+    // testing mock
+    mock: {
+      logThings: LogLevelDesc[] | 'all';
+      logger: Logger;
+      clearAll(): void;
+    };
   }
 
-  const getLogger: getLogger.GetLogger;
+  const getLogger: GetLogger;
 
-  export = getLogger;
+  export default getLogger;
 }

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,8 +1,9 @@
 import { ESLint, type Linter } from 'eslint';
+import type { LogLevelDesc as LogLevel } from 'loglevel';
 import type { Options as PrettierOptions } from 'prettier';
 
 /** Logging level for the traceback of the synchronous formatting process. */
-export type LogLevel = 'debug' | 'error' | 'info' | 'silent' | 'trace' | 'warn';
+export type { LogLevel };
 
 export type { PrettierOptions };
 

--- a/test/index.spec.ts
+++ b/test/index.spec.ts
@@ -1,3 +1,5 @@
+/* eslint-disable @typescript-eslint/unbound-method */
+
 import fsMock_ from 'node:fs';
 import path from 'node:path';
 


### PR DESCRIPTION
## Summary
- Align the exported `LogLevel` type with `loglevel`'s `LogLevelDesc`
- Update the `loglevel-colored-level-prefix` shim and mock typings to use upstream `loglevel` types
- Add a patch changeset for the type compatibility fix

## Test plan
- [x] `yarn test`
- [x] `yarn lint`
- [x] `yarn build`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Updated log level type definitions to match `loglevel` (`LogLevelDesc`), improving consistency with exported typings.

* **Refactor**
  * Revised module type signatures and export shape for `loglevel-colored-level-prefix`, including optional initialization options.

* **Tests**
  * Adjusted Jest mock typings and behavior to reflect the updated `loglevel`-aligned interfaces.
  * Disabled a specific TypeScript ESLint rule for the test file to keep linting clean.
<!-- end of auto-generated comment: release notes by coderabbit.ai -->