### PR TITLE
Expose FormatOptions from CommonJS types

### DIFF
--- a/.changeset/breezy-bugs-fold.md
+++ b/.changeset/breezy-bugs-fold.md
@@ -1,0 +1,5 @@
+---
+"prettier-eslint": patch
+---
+
+Expose `FormatOptions` from the CommonJS type declarations.

--- a/index.d.ts
+++ b/index.d.ts
@@ -1,7 +1,14 @@
-import { analyze, format } from './lib/index.js';
+import {
+  FormatOptions as FormatOptions_,
+  analyze,
+  format,
+} from './lib/index.js';
 
 declare namespace prettierESLint {
   type Format = typeof format;
+
+  // eslint-disable-next-line no-restricted-syntax
+  type FormatOptions = FormatOptions_;
 
   interface PrettierESLint extends Format {
     analyze: typeof analyze;


### PR DESCRIPTION
## Summary
- Expose `FormatOptions` from the top-level CommonJS declaration namespace
- Add a patch changeset for the type declaration fix

## Test plan
- [x] `yarn lint`
- [x] `yarn build`
- [x] `yarn test`

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * `FormatOptions` type is now publicly available in type declarations for TypeScript users.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->